### PR TITLE
changed login criteria. Must have a ucsd email to login in now

### DIFF
--- a/src/components/auth-pill/auth-pill.js
+++ b/src/components/auth-pill/auth-pill.js
@@ -156,11 +156,17 @@ class AuthPill extends HTMLElement {
 
   async saveUserToDatabase(user) {
     try {
-      await supabase
+      const { error } = await supabase
         .from('users')
         .upsert([{ id: user.id, email: user.email }], { onConflict: ['id'] });
+      
+      if(error) {
+        throw error;
+      }
     } catch (err) {
       console.error('Failed to save user:', err);
+      await this.logout();
+      alert('Must have a UCSD account (@ucsd.edu) to login');
     }
   }
 


### PR DESCRIPTION
[#170 only ucsd accounts can login now](https://github.com/cse110-sp25-group15/cse110-sp25-group15/pull/137)
## :mag: Overview
Fixes the issue of non-UCSD accounts being able to login. Non-UCSD accounts are rejected and redirected to homepage. 
---
## :memo: Summary of Changes
• Adjusted the Row Level Security Policy in the users table in Supabase to check for the correct email domain ('@uced.edu) and adjusted error handling in saveUserToDatabase() function in auth-pill.js to catch rejection errors thrown by the RLS policy. When rejected, user is redirected to the homepage and error is displayed. 
---
## :open_file_folder: Files Changed
| File Path                                  | Description                                          |
| ------------------------------------------ | ---------------------------------------------------- |
| src\components\auth-pill\auth-pill.js | Adjusted error handling in saveUserToDatabase() to catch RLS rejections |
---
## :wrench: Type of Change
Select the most appropriate category:
• Bug fix [x]
• New feature [ ]
• Refactor (non-breaking) [ ]
• Performance improvement [ ]
• Test updates [ ]
• Documentation update [ ]
• Styles Update [ ]
---
## :camera_with_flash: Screenshots (if applicable)
Include any relevant before/after visuals or logs.  

Before:  N/A
 
After:  N/A

---
## :blue_book: Additional Context
No conflicts with other functionality of app (as far as I know). This adjustment does not impact current users in database which are not of the @ucsd.edu domain. Will go through and get rid of those myself in database.