### PR TITLE
Listings name update

### DIFF
--- a/src/components/auth-pill/auth-pill.js
+++ b/src/components/auth-pill/auth-pill.js
@@ -209,9 +209,12 @@ class AuthPill extends HTMLElement {
 
   async _saveUserToDatabase(user) {
     try {
+      const displayName = user.email?.split('@')[0];
       const { error } = await supabase
         .from('users')
-        .upsert([{ id: user.id, email: user.email }], { onConflict: ['id'] });
+        .upsert([{ id: user.id, 
+          email: user.email,
+          display_name: displayName }], { onConflict: ['id'] });
       
       if (error) {
         throw error;

--- a/src/scripts/controllers/ListingsDisplayController.js
+++ b/src/scripts/controllers/ListingsDisplayController.js
@@ -176,7 +176,7 @@ export class ListingDisplayController {
       this.overlay.setAttribute('condition', listing.condition || '');
       this.overlay.setAttribute('date', listing.date_posted || '');
       this.overlay.setAttribute('description', listing.description || '');
-      this.overlay.setAttribute('lister-name', listing.lister_name || 'Unknown');
+      this.overlay.setAttribute('lister-name', listing.lister_name || ' * Must be signed in to view name *');
       
       // Handle multiple images - convert array to JSON string for the attribute
       let imagesAttr = '';


### PR DESCRIPTION
## :mag: Overview
> Made it so that we now save the user name of a user in supabase (previously the name column was just null and not used at all).  This is done by saving the username from the email. Ex. 'user69@ucsd.edu' -> username is: 'user69'. Additionally, a small change I updated the message that non signed in users see when viewing a listing. For name it used to say 'unknown' but its updated so it looks intentional and not like a bug.
---
## :memo: Summary of Changes
- updated _saveUserToDatabase function in auth-pill.js. In addition to what was already being upserted to supabase (user id, email etc.) it now upserts a user 'display_name'. Also changed line 179 in ListingsDisplayController, updated message users see when not signed and are trying to view the name of the person who posted the listing. Now says, "Must be signed in to view name". 
---
## :open_file_folder: Files Changed
| File Path                    | Description                                |
|-----------------------------|--------------------------------------------|
| `src\scripts\controllers\ListingsDisplayController.js` | updated message for non signed in users|
| `src\components\auth-pill\auth-pill.js` | upserts display_name to supabase now|
---
## :wrench: Type of Change
> Select the most appropriate category:
- [x ] Bug fix
- [] New feature
- [ ] Refactor (non-breaking)
- [x ] Performance improvement
- [ ] Test updates
- [ ] Documentation update
- [] Styles Update
---
## :camera_with_flash: Screenshots (if applicable)
> Include any relevant before/after visuals or logs.
Before:
N/A
After:
N/A
---
## :blue_book: Additional Context
> No conflicts